### PR TITLE
Send to error callback if filter is declined

### DIFF
--- a/lib/ng-transloadit.js
+++ b/lib/ng-transloadit.js
@@ -43,7 +43,9 @@ angular.module('ng-transloadit', []).factory('Transloadit', ['$http', '$rootScop
 
         $timeout(function() {
             $http.get(assemblyUrl).success(function(results) {
-              if (results.ok === 'ASSEMBLY_COMPLETED') {
+              if('error' in results){
+                options.error(results.message);
+              } else if (results.ok === 'ASSEMBLY_COMPLETED') {
                 options.uploaded(results);
               } else {
                 check(results.assembly_ssl_url);


### PR DESCRIPTION
Currently if a filter is declined the processing callback runs infinitely.  If the response contains an FILE_FILTER_DECLINED_FILE error, it should be sent to the error function.